### PR TITLE
Update GhPluginUpdater.php: fix after_install() return value

### DIFF
--- a/GhPluginUpdater.php
+++ b/GhPluginUpdater.php
@@ -118,7 +118,7 @@ class GhPluginUpdater
             activate_plugin($this->basename);
         }
 
-        return $result;
+        return $response;
     }
 
     /**


### PR DESCRIPTION
Returning `$result` (which is an array) instead of `$response` (which is a bool) causes a fatal error when using the class in multiple plugins